### PR TITLE
Noetic release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rqt_robot_dashboard)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED)

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,8 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>rqt_robot_dashboard</name>
   <version>0.5.7</version>
   <description>rqt_robot_dashboard provides an infrastructure for building robot dashboard plugins in rqt.</description>
@@ -14,15 +18,15 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>diagnostic_msgs</run_depend>
-  <run_depend version_gte="0.2.19">python_qt_binding</run_depend>
-  <run_depend>qt_gui</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend version_gte="0.3.1">rqt_console</run_depend>
-  <run_depend>rqt_gui</run_depend>
-  <run_depend>rqt_gui_py</run_depend>
-  <run_depend>rqt_nav_view</run_depend>
-  <run_depend>rqt_robot_monitor</run_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
+  <exec_depend version_gte="0.2.19">python_qt_binding</exec_depend>
+  <exec_depend>qt_gui</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend version_gte="0.3.1">rqt_console</exec_depend>
+  <exec_depend>rqt_gui</exec_depend>
+  <exec_depend>rqt_gui_py</exec_depend>
+  <exec_depend>rqt_nav_view</exec_depend>
+  <exec_depend>rqt_robot_monitor</exec_depend>
 
   <export>
     <rosdoc config="rosdoc.yaml" />

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
+
   <exec_depend>diagnostic_msgs</exec_depend>
   <exec_depend version_gte="0.2.19">python_qt_binding</exec_depend>
   <exec_depend>qt_gui</exec_depend>

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 
-try:
-    from distutils.core import setup
-except ImportError:
-    from setuptools import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+try:
+    from distutils.core import setup
+except ImportError:
+    from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
Following the guidelines to migrate packages to [noetic](http://wiki.ros.org/noetic/Migration)

- import setup from setuptools instead of distutils-core

- Bump CMake version to avoid CMP0048 warning
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.
