### PR TITLE
ROS2 Release Prep

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -17,8 +17,6 @@
 
   <author>Ze'ev Klapow</author>
 
-  <buildtool_depend>ament_python</buildtool_depend>
-
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
@@ -30,7 +28,7 @@
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
   <exec_depend>rqt_nav_view</exec_depend>
-  <exec_depend>rqt_robot_monitor</exec_depend>
+  <!--exec_depend>rqt_robot_monitor</exec_depend-->
 
   <export>
     <rosdoc config="rosdoc.yaml"/>

--- a/src/rqt_robot_dashboard/nav_view_dash_widget.py
+++ b/src/rqt_robot_dashboard/nav_view_dash_widget.py
@@ -31,6 +31,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from python_qt_binding.QtCore import QMutex, QMutexLocker, QSize
+# Note: rqt_nav_view has not been migrated to ROS2 yet
 from rqt_nav_view.nav_view import NavViewWidget
 
 from .icon_tool_button import IconToolButton


### PR DESCRIPTION
I'm not sure why we don't want `ament_python` as a `buildtool_depend`, but bloom doesn't like. 

Also, this removes the dependency on `rqt_nav_view` which is not released. 